### PR TITLE
Change find command to be case insensitive

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -79,7 +79,7 @@ Format: `find KEYWORD [MORE_KEYWORDS]`
 
 [NOTE]
 ====
-The search is case sensitive, the order of the keywords does not matter, only the name is searched,
+The search is case insensitive, the order of the keywords does not matter, only the name is searched,
 and persons matching at least one keyword will be returned (i.e. `OR` search).
 ====
 

--- a/src/seedu/addressbook/commands/FindCommand.java
+++ b/src/seedu/addressbook/commands/FindCommand.java
@@ -49,7 +49,7 @@ public class FindCommand extends Command {
     private List<ReadOnlyPerson> getPersonsWithNameContainingAnyKeyword(Set<String> keywords) {
         final List<ReadOnlyPerson> matchedPersons = new ArrayList<>();
         for (ReadOnlyPerson person : addressBook.getAllPersons()) {
-            final Set<String> wordsInName = new HashSet<>(person.getName().getWordsInName());
+            final Set<String> wordsInName = new HashSet<>(person.getName().getWordsInNameInUpperCase());
             if (!Collections.disjoint(wordsInName, keywords)) {
                 matchedPersons.add(person);
             }

--- a/src/seedu/addressbook/data/person/Name.java
+++ b/src/seedu/addressbook/data/person/Name.java
@@ -1,9 +1,9 @@
 package seedu.addressbook.data.person;
 
-import seedu.addressbook.data.exception.IllegalValueException;
-
 import java.util.Arrays;
 import java.util.List;
+
+import seedu.addressbook.data.exception.IllegalValueException;
 
 /**
  * Represents a Person's name in the address book.
@@ -41,6 +41,13 @@ public class Name {
      */
     public List<String> getWordsInName() {
         return Arrays.asList(fullName.split("\\s+"));
+    }
+
+    /**
+     * Retrieves a listing of every word in the name converted to uppercase, in order.
+     */
+    public List<String> getWordsInNameInUpperCase() {
+        return Arrays.asList(fullName.toUpperCase().split("\\s+"));
     }
 
     @Override

--- a/src/seedu/addressbook/parser/Parser.java
+++ b/src/seedu/addressbook/parser/Parser.java
@@ -242,8 +242,8 @@ public class Parser {
                     FindCommand.MESSAGE_USAGE));
         }
 
-        // keywords delimited by whitespace
-        final String[] keywords = matcher.group("keywords").split("\\s+");
+        // keywords converted to uppercase and then delimited by whitespace.
+        final String[] keywords = matcher.group("keywords").toUpperCase().split("\\s+");
         final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
         return new FindCommand(keywordSet);
     }

--- a/test/expected.txt
+++ b/test/expected.txt
@@ -213,8 +213,9 @@
 || 0 persons listed!
 || ===================================================
 || Enter command: || [Command entered:  find betsy]
+|| 	1. Betsy Choo Tags: [secretive]
 || 
-|| 0 persons listed!
+|| 1 persons listed!
 || ===================================================
 || Enter command: || [Command entered:  find Betsy]
 || 	1. Betsy Choo Tags: [secretive]

--- a/test/java/seedu/addressbook/commands/FindCommandTest.java
+++ b/test/java/seedu/addressbook/commands/FindCommandTest.java
@@ -25,8 +25,8 @@ public class FindCommandTest {
         //same word, same case: matched
         assertFindCommandBehavior(new String[]{"Amy"}, Arrays.asList(td.amy));
 
-        //same word, different case: not matched
-        assertFindCommandBehavior(new String[]{"aMy"}, Collections.emptyList());
+        //same word, different case: matched
+        assertFindCommandBehavior(new String[]{"aMy"}, Arrays.asList(td.amy));
 
         //partial word: not matched
         assertFindCommandBehavior(new String[]{"my"}, Collections.emptyList());
@@ -54,6 +54,9 @@ public class FindCommandTest {
     }
 
     private FindCommand createFindCommand(String[] keywords) {
+        for (int i = 0; i < keywords.length; i++) {
+            keywords[i] = keywords[i].toUpperCase();
+        }
         final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
         FindCommand command = new FindCommand(keywordSet);
         command.setData(addressBook, Collections.emptyList());

--- a/test/java/seedu/addressbook/parser/ParserTest.java
+++ b/test/java/seedu/addressbook/parser/ParserTest.java
@@ -176,7 +176,7 @@ public class ParserTest {
 
     @Test
     public void parse_findCommandValidArgs_parsedCorrectly() {
-        final String[] keywords = { "key1", "key2", "key3" };
+        final String[] keywords = { "KEY1", "KEY2", "KEY3" };
         final Set<String> keySet = new HashSet<>(Arrays.asList(keywords));
 
         final String input = "find " + String.join(" ", keySet);
@@ -187,7 +187,7 @@ public class ParserTest {
 
     @Test
     public void parse_findCommandDuplicateKeys_parsedCorrectly() {
-        final String[] keywords = { "key1", "key2", "key3" };
+        final String[] keywords = { "KEY1", "KEY2", "KEY3" };
         final Set<String> keySet = new HashSet<>(Arrays.asList(keywords));
 
         // duplicate every keyword


### PR DESCRIPTION
Change implementation of find command to be case insensitive
Update the User Guide to reflect the change in the find command to case insensitive
Add an additional method getWordsInNameInUpperCase() which is an alternative to getWordsInName() method in Name.java with the difference being the former returns in uppercase format to facilitate find command being case insensitive
Update Parser.java's prepareFind(String args) method to convert keywords to uppercase to facilitate find command being case insensitive
Update test/expected.txt to match with the change of find command to be case insensitive
Update FindCommandTest.java JUnit tests to match the change in the find command to case insensitive (note since the JUnit tests for FindCommandTest.java does not use the Parser.java's prepareFind(String args) like a normal find command method would in practice, an additional code has to be added in the createFindCommand method which FindCommandTest.java JUnit Test used to test the find command to convert the keywords to uppercase to facilitate the change in the find command to case insensitive
Update ParserTest.java's JUnit tests to match the change in the find command to case insensitive where the parse_findCommandValidArgs_parsedCorrectly() method and parse_findCommandDuplicateKeys_parsedCorrectly() methods are changed accordingly to show the keywords as uppercase to match the change in find command to case insensitive
Test with the updated JUnit tests and I/O tests and it shows the correct outputs in other words, for I/O tests, no difference in the actual.txt and expected.txt and for JUnit tests, all tests pass
Check source code to ensure despite updates to the source code, it still meets coding standards and matches OOP style